### PR TITLE
Fix Rubocop for checks with more than 50 issues

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -18,7 +18,7 @@ require 'time'
 
 @headers = {
   "Content-Type": 'application/json',
-  "Accept": 'application/vnd.github.antiope-preview+json',
+  "Accept": 'application/vnd.github.v3+json',
   "Authorization": "Bearer #{@GITHUB_TOKEN}",
   "User-Agent": 'github-actions-rubocop'
 }
@@ -52,6 +52,8 @@ def update_check(id, conclusion, output)
     'conclusion' => conclusion,
     'output' => output
   }
+
+  puts body.inspect
 
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -58,19 +58,23 @@ def update_check(id, conclusion, output)
     'completed_at' => #{Time.now.iso8601},
     'conclusion' => #{conclusion},"
 
-  puts "------output"
-  #puts output.inspect
-  puts "-------"
+
   unless output.nil?
     output = {
       title: output[:title],
       summary: output[:summary],
       annotations: []
     }
+
+    body['output'] = output
   end
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"
+
+  puts "------body"
+  puts body.inspect
+  puts "-------"
 
   resp = http.patch(path, body.to_json, @headers)
   puts "resp.code.to_i: #{resp.code.to_i}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -46,7 +46,7 @@ end
 def update_check(id, conclusion, output)
   body = {
     'name' => @check_name,
-    'head_sha' => @GITHUB_SHA,
+    # 'head_sha' => @GITHUB_SHA,
     'status' => 'completed',
     'completed_at' => Time.now.iso8601,
     'conclusion' => conclusion,

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -46,7 +46,6 @@ end
 def update_check(id, conclusion, output)
   body = {
     'name' => @check_name,
-    'head_sha' => @GITHUB_SHA,
     'status' => 'completed',
     'completed_at' => Time.now.iso8601,
     'conclusion' => conclusion,
@@ -123,6 +122,7 @@ def run
     output['annotations'].each_slice(50).each do |annotation_slice|
       output_dup = output.dup
       output_dup['annotations'] = annotation_slice
+
       update_check(id, conclusion, output_dup)
     end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -53,8 +53,6 @@ def update_check(id, conclusion, output)
     'output' => output
   }
 
-  puts body.inspect
-
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -129,7 +129,7 @@ def run
     raise if conclusion == 'failure'
   rescue StandardError
     update_check(id, 'failure', nil)
-    raise
+    #raise
   end
 end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -61,8 +61,8 @@ def update_check(id, conclusion, output)
   puts "------output"
   #puts output.inspect
   puts "-------"
-  if annotations.present?
-    annotations = {
+  if output.present?
+    output = {
       title: output[:title],
       summary: output[:summary],
       annotations: []

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -61,7 +61,7 @@ def update_check(id, conclusion, output)
   puts "------output"
   #puts output.inspect
   puts "-------"
-  if output.present?
+  unless output.nil?
     output = {
       title: output[:title],
       summary: output[:summary],

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -137,7 +137,13 @@ def run
     conclusion = results['conclusion']
     output = results['output']
     puts "running update check like normal"
-    update_check(id, conclusion, output)
+    # limit to 50 annoations per update
+    output["annotations"].each_slice(50).each do |annotation_slice|
+      output_dup = output.dup
+      output_dup["annotations"] = annotation_slice
+      update_check(id, conclusion, output_dup)
+    end
+
 
     raise if conclusion == 'failure'
   rescue StandardError

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -129,7 +129,7 @@ def run
     raise if conclusion == 'failure'
   rescue StandardError
     update_check(id, 'failure', nil)
-    #raise
+    raise
   end
 end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -53,6 +53,11 @@ def update_check(id, conclusion, output)
     'output' => output
   }
 
+  puts "'name' => #{@check_name},
+    'status' => 'completed',
+    'completed_at' => #{Time.now.iso8601},
+    'conclusion' => #{conclusion},"
+
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -59,12 +59,12 @@ def update_check(id, conclusion, output)
     'conclusion' => #{conclusion},"
 
   puts "------output"
-  puts output.inspect
+  #puts output.inspect
   puts "-------"
   if annotations.present?
     annotations = {
-      title: annotations[:title],
-      summary: annotations[:summary],
+      title: output[:title],
+      summary: output[:summary],
       annotations: []
     }
   end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -59,22 +59,22 @@ def update_check(id, conclusion, output)
     'conclusion' => #{conclusion},"
 
 
-  unless output.nil?
-    output = {
-      title: output[:title],
-      summary: output[:summary],
-      annotations: []
-    }
+  # unless output.nil?
+  #   output = {
+  #     title: output[:title],
+  #     summary: output[:summary],
+  #     annotations: []
+  #   }
 
-    body['output'] = output
-  end
+  #   body['output'] = output
+  # end
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"
 
-  puts "------body"
-  puts body.inspect
-  puts "-------"
+  # puts "------body"
+  # puts body.inspect
+  # puts "-------"
 
   resp = http.patch(path, body.to_json, @headers)
   puts "resp.code.to_i: #{resp.code.to_i}"
@@ -137,7 +137,8 @@ def run
     conclusion = results['conclusion']
     output = results['output']
     puts "running update check like normal"
-    # limit to 50 annoations per update
+    # https://docs.github.com/en/rest/reference/checks#output-object
+    # annotations limited to 50 per request
     output["annotations"].each_slice(50).each do |annotation_slice|
       output_dup = output.dup
       output_dup["annotations"] = annotation_slice

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -63,7 +63,7 @@ def update_check(id, conclusion, output)
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"
 
   resp = http.patch(path, body.to_json, @headers)
-
+  puts "resp.code.to_i: #{resp.code.to_i}"
   raise resp.message if resp.code.to_i >= 300
 end
 

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -61,7 +61,13 @@ def update_check(id, conclusion, output)
   puts "------output"
   puts output.inspect
   puts "-------"
-
+  if annotations.present?
+    annotations = {
+      title: annotations[:title],
+      summary: annotations[:summary],
+      annotations: []
+    }
+  end
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -122,11 +122,12 @@ def run
     results = run_rubocop
     conclusion = results['conclusion']
     output = results['output']
-
+    puts "running update check like normal"
     update_check(id, conclusion, output)
 
     raise if conclusion == 'failure'
   rescue StandardError
+    puts "running update check in rescue"
     update_check(id, 'failure', nil)
     raise
   end

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -58,6 +58,10 @@ def update_check(id, conclusion, output)
     'completed_at' => #{Time.now.iso8601},
     'conclusion' => #{conclusion},"
 
+  puts "------output"
+  puts output.inspect
+  puts "-------"
+
   http = Net::HTTP.new('api.github.com', 443)
   http.use_ssl = true
   path = "/repos/#{@owner}/#{@repo}/check-runs/#{id}"
@@ -125,7 +129,7 @@ def run
     puts "running update check like normal"
     update_check(id, conclusion, output)
 
-    #raise if conclusion == 'failure'
+    raise if conclusion == 'failure'
   rescue StandardError
     puts "running update check in rescue"
     update_check(id, 'failure', nil)

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -125,7 +125,7 @@ def run
     puts "running update check like normal"
     update_check(id, conclusion, output)
 
-    raise if conclusion == 'failure'
+    #raise if conclusion == 'failure'
   rescue StandardError
     puts "running update check in rescue"
     update_check(id, 'failure', nil)


### PR DESCRIPTION
So on branches that totally aren't mine, sometimes there could in theory maybe be more than 50 rubocop issues.
Slice them in chunks of 50, and process them that way!